### PR TITLE
Add "Year" versions of movie queries to search

### DIFF
--- a/src/webshare.js
+++ b/src/webshare.js
@@ -33,6 +33,8 @@ const getQueries = (info) => {
       return [`${name} S${series}E${episode}`, `${name} ${series}x${episode}`];
     });
   } else {
+    // add queries with the release year appended, helps to find relevant files for movies with generic name like Mother (tt1216496) or Soul (tt2948372)
+    names.push(...names.map((name) => name + " " + info.year));
     return names;
   }
 };


### PR DESCRIPTION
Ahoj,

addon nevedel najst ziadne relevantne streamy pre filmy s prilis vseobecnymi nazvami, napr. Mother (tt1216496) alebo Soul (tt2948372). Prilis vseobecne nazvy sposobovali, ze na prvej strane WS hladania nevratilo nic relevantne.

Riesenia boli 2:
1. vyhladavanie suborov v cykle cez vsetky stranky, co znamenalo 30 WS callow (10 stranok x 3 queries). Testoval som a v konecnom dosledku to vracalo menej relevantnych streamov nez 2. riesenie
2. upresnit queries pomocou doplnenia roku vydania, ktore je casto v nazve suborov, co znamena 6 WS callov. Takto naslo kopu streamov.