### PR TITLE
Fix getUrl error handling and small cleanups

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple webshare.cz search and streaming.",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "nodemon src/server.js --dev",
+    "dev": "node --watch src/server.js --dev",
     "test": "jest",
     "format": "prettier . --write",
     "check-formatting": "prettier . --check"

--- a/src/addon.js
+++ b/src/addon.js
@@ -251,6 +251,11 @@ app.get("/getUrl/:ident", async (req, res) => {
     const ident = req.params.ident;
     const streamUrl = await getUrl(ident, req.query.token);
 
+    if (!streamUrl) {
+      res.status(404).send("Unable to resolve Webshare file link");
+      return;
+    }
+
     const now = new Date();
     // Expires 5 hours from now.
     const expiration = new Date(now.getTime() + 5 * 60 * 60 * 1000);
@@ -264,6 +269,7 @@ app.get("/getUrl/:ident", async (req, res) => {
     res.redirect(streamUrl);
   } catch (error) {
     console.error("Error in getUrl: ", error.code, error.message, error.stack);
+    res.status(502).send("Error while resolving Webshare file link");
   }
 });
 

--- a/src/webshare.js
+++ b/src/webshare.js
@@ -84,7 +84,6 @@ const login = async (user, saltedPassword) => {
 };
 
 const getById = async (id, token) => {
-  await needle("https://webshare.cz/api/file_info");
   const data = formencode({ ident: id, wst: token });
   const resp = await needle(
     "post",

--- a/test/addon.test.js
+++ b/test/addon.test.js
@@ -64,6 +64,18 @@ describe("GET /getUrl/:ident", () => {
     // Route requires :ident, so /getUrl/ should 404
     const res = await request(server).get(`/getUrl/`).expect(404);
   });
+
+  it("returns 404 when the file link cannot be resolved", async () => {
+    webshare.getUrl.mockResolvedValueOnce(null);
+
+    await request(server).get(`/getUrl/${ident}?token=${token}`).expect(404);
+  });
+
+  it("returns 502 when webshare.getUrl throws", async () => {
+    webshare.getUrl.mockRejectedValueOnce(new Error("fail"));
+
+    await request(server).get(`/getUrl/${ident}?token=${token}`).expect(502);
+  });
 });
 
 describe("POST /configure", () => {


### PR DESCRIPTION
Hello, love this project! I was digging into how it works and came across a few minor bugs while testing.

## Changes
- Return `404` when file link cannot be resolved and `502` on error (previously it hung until timeout)
- Remove a redundant request to WS on every meta lookup
- Use Node's built-in `--watch` instead of `nodemon`, which isn't a listed dependency.